### PR TITLE
Fix Button missing until screen resize

### DIFF
--- a/src/components/ReturnToTop/ReturnToTop.css
+++ b/src/components/ReturnToTop/ReturnToTop.css
@@ -19,3 +19,21 @@
 .app__returntotop_arrow-icon:hover {
     color: var(--color-golden);
 }
+
+@media screen and (max-width: 1150px) {
+    .btn1 {
+        display: none;
+    }
+}
+
+@media screen and (min-width: 1150px) {
+    .btn2 {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 900px) {
+    .btn2 {
+        display: none;
+    }
+}

--- a/src/components/ReturnToTop/ReturnToTop.jsx
+++ b/src/components/ReturnToTop/ReturnToTop.jsx
@@ -3,8 +3,8 @@ import { BsArrowUpSquare } from 'react-icons/bs';
 
 import './ReturnToTop.css';
 
-const ArrowBtn = () => (
-    <div className='app__returntotop'>
+const ArrowBtn = (props) => (
+    <div className={props.class}>
         <a href="#home">
             <BsArrowUpSquare 
                 className='app__returntotop_arrow-icon' 
@@ -29,32 +29,14 @@ const ReturnToTop = () => {
         };
     }, []);
 
-    const [widthPosition, setWidthPosition] = useState(0);
-
-    const handleResize = () => {
-        const width = window.innerWidth;
-        setWidthPosition(width);    
-    };
-
-    useEffect(() => {
-        window.addEventListener('resize', handleResize, { passive: true });
-
-        return () => {
-            window.removeEventListener('resize', handleResize);
-        };
-    }, []);
-
     return (
         <>
-        {(scrollPosition > 150 && 
-            widthPosition > 1150) && (
-                <ArrowBtn />
+        {(scrollPosition > 150 ) && (
+                <ArrowBtn class='app__returntotop btn1' />
         )}
 
-        {(scrollPosition > 1000 && 
-            widthPosition < 1150 && 
-            widthPosition > 900) && (
-                <ArrowBtn />
+        {(scrollPosition > 1000) && (
+                <ArrowBtn class='app__returntotop btn2' />
         )}
         </>
     )


### PR DESCRIPTION
- Fix: "Return to top" Button won't show when the page loads.
    - An event listener was listening for a page resize to determine if the button should show or not. When the page loads there is no event for it to evaluate so the statement was receiving "undefined" which is the same as "false". Therefore the button would only function properly after a page resize which triggers the event listener. 
    - I removed the event listener and logic related to page width in the component
    - I added media queries that mirrored the desired functionality but didn't have the downfall of depending on a page resize